### PR TITLE
Fixed nullcheck in browse endpoint fixes 106

### DIFF
--- a/KerbalStuff/blueprints/api.py
+++ b/KerbalStuff/blueprints/api.py
@@ -138,7 +138,7 @@ def browse():
     mods = Mod.query.filter(Mod.published)
     # detect total pages
     total_pages = math.ceil(mods.count() / count)
-    total_pages = 1 if total_pages > 0 else total_pages
+    total_pages = 1 if not total_pages > 0 else total_pages
     # order by field
     orderby = request.args.get('orderby')
     if orderby == "name":


### PR DESCRIPTION
The total number of pages was always set to 1. This breaks pagination, fixed the nullcheck 
